### PR TITLE
fix for CMake version

### DIFF
--- a/abseil-cpp/CMakeLists.txt
+++ b/abseil-cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ execute_process(COMMAND
 ExternalProject_Add(
   absl
   GIT_REPOSITORY https://github.com/abseil/abseil-cpp
+  GIT_TAG lts_2024_01_16
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX} -DCMAKE_BUILD_TYPE=Release -DABSL_ENABLE_INSTALL=ON -DBUILD_SHARED_LIBS=ON
   #INSTALL_COMMAND echo "install"
   )


### PR DESCRIPTION
abseil-cppはhttps://github.com/abseil/abseil-cpp/commit/f46495ea96f68fc3f6c394f099b2992743f6ff7f のコミットからCMake 3.10ではビルドできなくなりました。

CMake 3.10でもビルドできるように、CMakeListsで該当コミット以前のブランチを指定するようにしました。